### PR TITLE
fix(types): fix typescript interface and propTypes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 interface GoogleButtonProps {
+  onClick: () => any;
   label?: string;
   type?: "dark" | "light";
   disabled?: boolean;

--- a/src/GoogleButton.js
+++ b/src/GoogleButton.js
@@ -7,15 +7,15 @@ export default class GoogleButton extends PureComponent {
   static propTypes = {
     label: PropTypes.string,
     disabled: PropTypes.bool,
-    onClick: PropTypes.func,
-    type: PropTypes.oneOf(['light', 'dark'])
+    onClick: PropTypes.func.isRequired,
+    type: PropTypes.oneOf(['light', 'dark']),
+    style: PropTypes.object
   }
 
   static defaultProps = {
     label: 'Sign in with Google',
     disabled: false,
-    type: 'dark',
-    onClick: () => {}
+    type: 'dark'
   }
 
   state = {


### PR DESCRIPTION
- make onClick required, because otherwise this button is fairly useless
- add onClick to Typescript interface
- add style to propTypes


Fixes stuff that was missed with the most recent release