### PR TITLE
fix(types): fix typescript interface and propTypes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,9 @@
 import * as React from 'react';
 
-interface GoogleButtonProps {
+interface GoogleButtonProps extends HTMLAttributes<HTMLDivElement> {
   label?: string;
   type?: "dark" | "light";
   disabled?: boolean;
-  style?: object;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-interface GoogleButtonProps extends HTMLAttributes<HTMLDivElement> {
+interface GoogleButtonProps extends React.HTMLAttributes<HTMLDivElement> {
   label?: string;
   type?: "dark" | "light";
   disabled?: boolean;

--- a/src/GoogleButton.js
+++ b/src/GoogleButton.js
@@ -8,7 +8,8 @@ export default class GoogleButton extends PureComponent {
     label: PropTypes.string,
     disabled: PropTypes.bool,
     onClick: PropTypes.func,
-    type: PropTypes.oneOf(['light', 'dark'])
+    type: PropTypes.oneOf(['light', 'dark']),
+    style: PropTypes.object
   }
 
   static defaultProps = {


### PR DESCRIPTION
- TS: make GoogleButtonProps extend HTMLAttributes<HTMLDivElement> so it has all
  the props available to an HTML element (onClick, className, id, style, etc...)
- add style to propTypes

Fixes changes related to the latest release