### PR TITLE
Publish ES modules build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,14 +1,3 @@
 {
-  "presets": ["env", "react"],
-  "plugins": [
-    "transform-object-rest-spread",
-    "transform-class-properties",
-    "transform-export-extensions",
-    "transform-object-assign"
-  ],
-  "env": {
-    "test": {
-      "sourceMaps": "both"
-    }
-  }
+  "presets": ["./.babelrc.js"]
 }

--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,0 +1,21 @@
+module.exports = {
+  presets: [
+    ['env', {
+      modules: process.env.BABEL_ENV === 'es'
+        ? false
+        : 'commonjs'
+    }],
+    'react'
+  ],
+  plugins: [
+    'transform-object-rest-spread',
+    'transform-class-properties',
+    'transform-export-extensions',
+    'transform-object-assign'
+  ],
+  env: {
+    test: {
+      sourceMaps: 'both'
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ examples/basic/*js
 docs
 dist
 lib
+es
 *.log

--- a/.npmignore
+++ b/.npmignore
@@ -6,6 +6,7 @@ tests
 coverage
 .istanbul.yml
 .babelrc
+.babelrc.js
 SUMMARY.md
 webpack.config.js
 .eslintignore

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:es": "cross-env BABEL_ENV=es babel src --out-dir es",
     "build:umd": "cross-env NODE_ENV=development BABEL_ENV=commonjs webpack src/index.js dist/react-google-button.js --config webpack.config.js",
     "build:umd:min": "cross-env NODE_ENV=production BABEL_ENV=commonjs webpack -p src/index.js dist/react-google-button.min.js --config webpack.config.js",
-    "build": "npm run clean && npm run build:commonjs && npm run build:umd && npm run build:umd:min && npm run build:example",
+    "build": "npm run clean && npm run build:es && npm run build:commonjs && npm run build:umd && npm run build:umd:min && npm run build:example",
     "serve": "npm run build && serve examples/basic",
     "watch:umd": "npm run build:umd -- --progress --colors --watch",
     "watch:lib": "npm run build:lib -- --watch",


### PR DESCRIPTION
The package.json contains a `module` field, but the `es/index.js` file
is not published in the package. While bundlers like Webpack will just
fall back to `main`, eslint-plugin-import complains that the path does
not resolve to a real file.

This patch runs the existing `build:es` npm script before publishing and
adds the `es` folder to the package, so that you can `import`
react-google-button in ES modules bundlers.

I moved the babel config into a custom preset (sort of), because I don't
think you can override options for a single preset using the JSON env
syntax. When BABEL_ENV=es, ES modules syntax is not compiled.

Lmk what you think!