### PR TITLE
fix GoogleButton export

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,2 @@
-export { GoogleButton } from './GoogleButton'
+export GoogleButton from './GoogleButton'
 export default from './GoogleButton'


### PR DESCRIPTION
`GoogleButton.js` only exports a default, so this ended up just
exporting `GoogleButton` as undefined. As of Webpack@4, importing things
that don't exist is an error.