### PR TITLE
Prevent button text from being selected

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -11,7 +11,8 @@ const baseStyle = {
   borderRadius: '1px',
   transition: 'background-color .218s, border-color .218s, box-shadow .218s',
   fontFamily: 'Roboto,arial,sans-serif',
-  cursor: 'pointer'
+  cursor: 'pointer',
+  userSelect: 'none'
 }
 
 export const darkStyle = {


### PR DESCRIPTION
Minor UX improvement: Currently, double clicking / dragging the button (across the text region) selects the text, which is odd behavior for a button. This change fixes that.