### PR TITLE
fix(chore): fix wrong path in 'main' field of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-google-button",
   "version": "0.7.1",
-  "main": "lib/index.js",
+  "main": "es/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
   "unpkg": "dist/react-google-button.min.js",


### PR DESCRIPTION
### Description

I wasn't able to import this module in my app code because the build output goes into an `es` folder instead of into the `lib` folder referenced by the `main` field in `package.json`.

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
* #31 